### PR TITLE
Add motor angle test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@ This project uses WPILib + Gradle. Just clone and run:
 
 Everything will be downloaded and built automatically.
 
-## Encoder Test
+## Test Mode
 
-When running in **Test** mode, the robot will reset the antenna encoder and
-continuously publish the current encoder reading to SmartDashboard under the key
-"Antenna Encoder". This allows you to verify encoder wiring and functionality
-without commanding the motor. To run the test:
+When running in **Test** mode, the robot resets the antenna encoder and
+publishes the current reading to SmartDashboard under the key `Antenna Encoder`.
+Additional controls allow the motor to be driven to a specific angle. To use
+the test mode:
 
 1. Deploy the robot code and select **Test** mode in the driver station.
 2. Open SmartDashboard and watch the value labeled `Antenna Encoder`.
-3. Manually rotate the antenna; the displayed value should change in degrees.
+3. (Optional) Set `Run Motor Test` to true to enable motor movement.
+4. Adjust `Target Angle` (degrees) and `Motor Speed %` as desired. The motor
+   will rotate until the encoder is within 1 degree of the target and then stop.
+5. Set `Run Motor Test` to false when finished to keep the motor idle.

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -6,6 +6,7 @@
 
 #include <frc2/command/CommandScheduler.h>
 #include <frc/smartdashboard/SmartDashboard.h>
+#include <cmath>
 
 Robot::Robot() {}
 
@@ -64,11 +65,28 @@ void Robot::TeleopPeriodic() {}
  */
 void Robot::TestInit() {
   m_container.GetMotorSubsystem().ResetEncoder();
+  frc::SmartDashboard::PutBoolean("Run Motor Test", false);
+  frc::SmartDashboard::PutNumber("Target Angle", 45.0);
+  frc::SmartDashboard::PutNumber("Motor Speed %", 0.1);
 }
 
 void Robot::TestPeriodic() {
   double pos = m_container.GetMotorSubsystem().GetEncoderPosition();
   frc::SmartDashboard::PutNumber("Antenna Encoder", pos);
+
+  bool run = frc::SmartDashboard::GetBoolean("Run Motor Test", false);
+  double target = frc::SmartDashboard::GetNumber("Target Angle", 45.0);
+  double speed = frc::SmartDashboard::GetNumber("Motor Speed %", 0.1);
+
+  if (run) {
+    if (std::abs(target - pos) <= 1.0) {
+      m_container.GetMotorSubsystem().StopMotor();
+    } else {
+      m_container.GetMotorSubsystem().MoveToAngle(target, speed);
+    }
+  } else {
+    m_container.GetMotorSubsystem().StopMotor();
+  }
 }
 
 /**

--- a/src/main/cpp/subsystems/MotorSubsystem.cpp
+++ b/src/main/cpp/subsystems/MotorSubsystem.cpp
@@ -1,5 +1,6 @@
 #include "subsystems/MotorSubsystem.h"
 #include "Constants.h"
+#include <cmath>
 
 MotorSubsystem::MotorSubsystem()
     : m_motor{MotorConstants::kMotorPWMPin},
@@ -14,4 +15,14 @@ double MotorSubsystem::GetEncoderPosition() const {
 
 void MotorSubsystem::ResetEncoder() {
   m_encoder.Reset();
+}
+
+void MotorSubsystem::MoveToAngle(double angleDeg, double speedPercent) {
+  double error = angleDeg - GetEncoderPosition();
+  double output = std::copysign(speedPercent, error);
+  m_motor.Set(output);
+}
+
+void MotorSubsystem::StopMotor() {
+  m_motor.StopMotor();
 }

--- a/src/main/include/subsystems/MotorSubsystem.h
+++ b/src/main/include/subsystems/MotorSubsystem.h
@@ -10,6 +10,8 @@ class MotorSubsystem : public frc2::SubsystemBase {
 
   double GetEncoderPosition() const;
   void ResetEncoder();
+  void MoveToAngle(double angleDeg, double speedPercent);
+  void StopMotor();
 
  private:
   frc::PWMVictorSPX m_motor;


### PR DESCRIPTION
## Summary
- allow test mode to drive the antenna motor toward an angle
- add helper methods to `MotorSubsystem` for angle control and stopping
- document the new test procedure in README, including a stop step

## Testing
- `./gradlew build` *(fails: No Toolchain Found)*

------
https://chatgpt.com/codex/tasks/task_e_684638ed3598832da9a7dd3b663eb76e