### PR TITLE
Add motor angle test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ This project uses WPILib + Gradle. Just clone and run:
 
 Everything will be downloaded and built automatically.
 
-## Encoder Test
+## Test Mode
 
-When running in **Test** mode, the robot will reset the antenna encoder and
-continuously publish the current encoder reading to SmartDashboard under the key
-"Antenna Encoder". This allows you to verify encoder wiring and functionality
-without commanding the motor. To run the test:
+When running in **Test** mode, the robot resets the antenna encoder and
+publishes the current reading to Shuffleboard under the key `Antenna Encoder` in
+the `Test` tab. Additional controls allow the motor to be driven to a specific
+angle. To use the test mode:
 
 1. Deploy the robot code and select **Test** mode in the driver station.
-2. Open SmartDashboard and watch the value labeled `Antenna Encoder`.
-3. Manually rotate the antenna; the displayed value should change in degrees.
+2. Open Shuffleboard and watch the value labeled `Antenna Encoder` on the `Test`
+   tab.  A `Motor Current` bar shows current draw from the PDP.
+3. (Optional) Set `Run Motor Test` to true to enable motor movement.
+4. Adjust `Target Angle` (degrees) and `Motor Speed %` as desired. The motor
+   will rotate until the encoder is within 1 degree of the target and then stop.
+5. Set `Run Motor Test` to false when finished to keep the motor idle.

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -5,7 +5,10 @@
 #include "Robot.h"
 
 #include <frc2/command/CommandScheduler.h>
-#include <frc/smartdashboard/SmartDashboard.h>
+#include <frc/shuffleboard/Shuffleboard.h>
+#include <frc/shuffleboard/BuiltInWidgets.h>
+#include <networktables/GenericEntry.h>
+#include <cmath>
 
 Robot::Robot() {}
 
@@ -64,11 +67,52 @@ void Robot::TeleopPeriodic() {}
  */
 void Robot::TestInit() {
   m_container.GetMotorSubsystem().ResetEncoder();
+  auto& tab = frc::Shuffleboard::GetTab("Test");
+
+  m_runEntry =
+      tab.Add("Run Motor Test", false)
+          .WithWidget(frc::BuiltInWidgets::kToggleButton)
+          .GetEntry();
+  m_targetEntry =
+      tab.Add("Target Angle", 45.0)
+          .WithWidget(frc::BuiltInWidgets::kTextView)
+          .GetEntry();
+  m_speedEntry =
+      tab.Add("Motor Speed %", 0.1)
+          .WithWidget(frc::BuiltInWidgets::kTextView)
+          .GetEntry();
+  m_encoderEntry =
+      tab.Add("Antenna Encoder", 0.0)
+          .WithWidget(frc::BuiltInWidgets::kNumberBar)
+          .GetEntry();
+  m_currentEntry =
+      tab.Add("Motor Current", 0.0)
+          .WithWidget(frc::BuiltInWidgets::kNumberBar)
+          .GetEntry();
 }
 
 void Robot::TestPeriodic() {
   double pos = m_container.GetMotorSubsystem().GetEncoderPosition();
-  frc::SmartDashboard::PutNumber("Antenna Encoder", pos);
+  if (m_encoderEntry) {
+    m_encoderEntry->SetDouble(pos);
+  }
+  if (m_currentEntry) {
+    m_currentEntry->SetDouble(m_container.GetMotorSubsystem().GetCurrentDraw());
+  }
+
+  bool run = m_runEntry ? m_runEntry->GetBoolean(false) : false;
+  double target = m_targetEntry ? m_targetEntry->GetDouble(45.0) : 45.0;
+  double speed = m_speedEntry ? m_speedEntry->GetDouble(0.1) : 0.1;
+
+  if (run) {
+    if (std::abs(target - pos) <= 1.0) {
+      m_container.GetMotorSubsystem().StopMotor();
+    } else {
+      m_container.GetMotorSubsystem().MoveToAngle(target, speed);
+    }
+  } else {
+    m_container.GetMotorSubsystem().StopMotor();
+  }
 }
 
 /**

--- a/src/main/cpp/subsystems/MotorSubsystem.cpp
+++ b/src/main/cpp/subsystems/MotorSubsystem.cpp
@@ -1,5 +1,7 @@
 #include "subsystems/MotorSubsystem.h"
 #include "Constants.h"
+#include <cmath>
+#include <frc/DriverStation.h>
 
 MotorSubsystem::MotorSubsystem()
     : m_motor{MotorConstants::kMotorPWMPin},
@@ -14,4 +16,22 @@ double MotorSubsystem::GetEncoderPosition() const {
 
 void MotorSubsystem::ResetEncoder() {
   m_encoder.Reset();
+}
+
+void MotorSubsystem::MoveToAngle(double angleDeg, double speedPercent) {
+  double error = angleDeg - GetEncoderPosition();
+  double speed = std::clamp(speedPercent, -1.0, 1.0);
+  double output = std::copysign(speed, error);
+  m_motor.Set(output);
+  if (std::abs(speedPercent) > 1.0) {
+    frc::DriverStation::ReportWarning("Speed percent out of range; clamped");
+  }
+}
+
+void MotorSubsystem::StopMotor() {
+  m_motor.StopMotor();
+}
+
+double MotorSubsystem::GetCurrentDraw() const {
+  return m_pdp.GetCurrent(MotorConstants::kPDPChannel);
 }

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -24,4 +24,5 @@ namespace MotorConstants {
 inline constexpr int kMotorPWMPin = 0;
 inline constexpr int kEncoderChannelA = 0;
 inline constexpr int kEncoderChannelB = 1;
+inline constexpr int kPDPChannel = 0;
 }  // namespace MotorConstants

--- a/src/main/include/Robot.h
+++ b/src/main/include/Robot.h
@@ -8,6 +8,7 @@
 
 #include <frc/TimedRobot.h>
 #include <frc2/command/CommandPtr.h>
+#include <networktables/GenericEntry.h>
 
 #include "RobotContainer.h"
 
@@ -32,4 +33,10 @@ class Robot : public frc::TimedRobot {
   std::optional<frc2::CommandPtr> m_autonomousCommand;
 
   RobotContainer m_container;
+
+  nt::GenericEntry* m_encoderEntry = nullptr;
+  nt::GenericEntry* m_runEntry = nullptr;
+  nt::GenericEntry* m_targetEntry = nullptr;
+  nt::GenericEntry* m_speedEntry = nullptr;
+  nt::GenericEntry* m_currentEntry = nullptr;
 };

--- a/src/main/include/subsystems/MotorSubsystem.h
+++ b/src/main/include/subsystems/MotorSubsystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <frc/motorcontrol/PWMVictorSPX.h>
+#include <frc/motorcontrol/Spark.h>
+#include <frc/PowerDistribution.h>
 #include <frc/Encoder.h>
 #include <frc2/command/SubsystemBase.h>
 
@@ -10,8 +11,12 @@ class MotorSubsystem : public frc2::SubsystemBase {
 
   double GetEncoderPosition() const;
   void ResetEncoder();
+  void MoveToAngle(double angleDeg, double speedPercent);
+  void StopMotor();
+  double GetCurrentDraw() const;
 
  private:
-  frc::PWMVictorSPX m_motor;
+  frc::Spark m_motor;
   frc::Encoder m_encoder;
+  frc::PowerDistribution m_pdp{1, frc::PowerDistribution::ModuleType::kCTRE};
 };


### PR DESCRIPTION
## Summary
- allow test mode to drive the antenna motor toward an angle
- add helper methods to `MotorSubsystem` for angle control and stopping
- document the new test procedure in README, including a stop step
- use Shuffleboard widgets for test controls instead of SmartDashboard
- fix Shuffleboard entry types to resolve compilation errors
- display PDP current draw when testing the motor
- clamp motor speed and report warnings if out of range
- switch to Spark PWM controller class

## Testing
- `./gradlew build` *(fails: No Toolchain Found)*


------
https://chatgpt.com/codex/tasks/task_e_684638ed3598832da9a7dd3b663eb76e